### PR TITLE
tweak bucket ops in deploy_model notebook

### DIFF
--- a/notebooks/deploy_model.ipynb
+++ b/notebooks/deploy_model.ipynb
@@ -131,19 +131,19 @@
    "outputs": [],
    "source": [
     "# create a bucket to upload the model file to\n",
-    "# NOTE we delete any existing model file and re-create the bucket\n",
+    "# Note: if the model file already exists we delete it\n",
     "model_bucket = os.environ.get('MODEL_BUCKET', 'models')\n",
     "model_dir = os.environ.get('MODEL_DIR', 'models')\n",
     "model_file = 'model.joblib'\n",
     "model_path = '{}/{}'.format(model_dir, model_file)\n",
     "\n",
     "try:\n",
+    "    # delete model file if if exists \n",
     "    mc.remove_object(model_bucket, model_file)\n",
-    "    mc.remove_bucket(model_bucket)\n",
-    "except NoSuchBucket as nsb:\n",
-    "    print('Cleaning up bucket [{}] failed: {}'.format(model_bucket, nsb.message))\n",
-    "print('Creating bucket [{}]'.format(model_bucket))\n",
-    "mc.make_bucket(model_bucket)"
+    "except NoSuchBucket:\n",
+    "    # the bucket doesn't exist - create it\n",
+    "    print('Creating bucket [{}]'.format(model_bucket))\n",
+    "    mc.make_bucket(model_bucket)"
    ]
   },
   {
@@ -183,7 +183,7 @@
    "outputs": [],
    "source": [
     "# check whether the model file is there\n",
-    "for o in mc.list_objects('models'):\n",
+    "for o in mc.list_objects(model_bucket, prefix=model_file):\n",
     "    print(o)"
    ]
   },


### PR DESCRIPTION
This PR tweaks the object storage code:
 - don't delete bucket if it already exists to avoid having to recreate it
 - apply filter to `list_objects` call to limit output to the model file

Notebook output for the relevant cells:

bucket already exists:
![image](https://user-images.githubusercontent.com/13068832/99846916-0eb17b80-2b2c-11eb-95aa-ec4066ce6acc.png)

bucket does not exist:
![image](https://user-images.githubusercontent.com/13068832/99847771-70261a00-2b2d-11eb-8d14-f963613724ab.png)
